### PR TITLE
Imported typing to make repo compatible with Python 3.8

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -24,8 +24,8 @@ def main(model_name: str, server_port: int) -> None:
     else:
         model, tokenizer = build_model_and_tokenizer_for(model_name)
 
-        def inference_fn(history: list[str], user_input: str,
-                         generation_settings: dict[str, t.Any],
+        def inference_fn(history: t.List[str], user_input: str,
+                         generation_settings: t.Dict[str, t.Any],
                          *char_settings: t.Any) -> str:
             # Brittle. Comes from the order defined in gradio_ui.py.
             [

--- a/src/model.py
+++ b/src/model.py
@@ -88,7 +88,7 @@ def run_raw_inference(model: transformers.AutoModelForCausalLM,
             "Couldn't find user message in the model's output. What?")
 
 
-def _build_bad_words_list_for(_model_name: str) -> list[str]:
+def _build_bad_words_list_for(_model_name: str) -> t.List[str]:
     '''Builds a list of bad words for the given model.'''
 
     # NOTE(11b): This was implemented as a function because each model size

--- a/src/parsing.py
+++ b/src/parsing.py
@@ -1,4 +1,5 @@
 import re
+import typing as t
 
 BAD_CHARS_FOR_REGEX_REGEX = re.compile(r"[-\/\\^$*+?.()|[\]{}]")
 
@@ -8,7 +9,7 @@ def _sanitize_string_for_use_in_a_regex(string: str) -> str:
     return BAD_CHARS_FOR_REGEX_REGEX.sub(r"\\\g<0>", string)
 
 
-def parse_messages_from_str(string: str, names: list[str]) -> list[str]:
+def parse_messages_from_str(string: str, names: t.List[str]) -> t.List[str]:
     '''
     Given a big string containing raw chat history, this function attempts to
     parse it out into a list where each item is an individual message.
@@ -40,6 +41,6 @@ def parse_messages_from_str(string: str, names: list[str]) -> list[str]:
     return messages
 
 
-def serialize_chat_history(history: list[str]) -> str:
+def serialize_chat_history(history: t.List[str]) -> str:
     '''Given a structured chat history object, collapses it down to a string.'''
     return "\n".join(history)


### PR DESCRIPTION
Colab uses Python 3.8, while list[str] and such were only implemented in Python 3.9