### PR TITLE
fix: forcefully disable KAI's chat mode

### DIFF
--- a/src/koboldai_client.py
+++ b/src/koboldai_client.py
@@ -47,6 +47,11 @@ def run_raw_inference_on_kai(
     payload = {
         "prompt": prompt,
 
+        # The config.json for our models enables chat mode by default, which
+        # we don't want yet since only the dev fork can handle our model
+        # properly at the moment, and we're bundling the stable version here.
+        "chatmode": False,
+
         # Incredibly low max len for reasons explained in the "while True" loop
         # below.
         "max_length": 32,


### PR DESCRIPTION
I turned on `chatmode` by default for our models on HF to give KAI users a better experience as per Henk's suggestion, but our current inference code here needs it to be off since our models aren't well-supported in the stable version of KAI yet (which is what we use as an inference server ATM).

This PR fixes that by forcefully disabling `chatmode` when running inference.