### PR TITLE
Revert gradio version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-gradio
+gradio<=3.18.0
 requests


### PR DESCRIPTION
Gradio's 3.19 update most likely changed something related to loading in .json files. Since this UI is depreciated, I think it's easier to just keep Gradio at 3.18 rather than try to adapt to the new version.